### PR TITLE
 Update to devel branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+DTLSSocket/dtls.c
+build/

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,8 @@ setup(
                  "DTLSSocket/tinydtls/peer.c",
                  "DTLSSocket/tinydtls/session.c",
                  "DTLSSocket/tinydtls/aes/rijndael.c",
-                 "DTLSSocket/tinydtls/sha2/sha2.c"
+                 "DTLSSocket/tinydtls/sha2/sha2.c",
+                 "DTLSSocket/tinydtls/platform-specific/dtls_prng_posix.c",
                  ],
                 include_dirs=['DTLSSocket/tinydtls'],
                 define_macros=[('DTLSv12', '1'),


### PR DESCRIPTION
This updates the upstream submodule to the latest devel branch, which includes a fix for https://github.com/chrysn/aiocoap/issues/167. Files that now need to be compiled in addition to the old ones are now included in setup.py, solving the import errors described there.

As "bycatch" (in a separate commit), a .gitignore that'll keep build artifacts out of git is created.