### PR TITLE
setup: Explicitly compile ecc.c

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
                  "DTLSSocket/tinydtls/crypto.c",
                  "DTLSSocket/tinydtls/dtls.c",
                  "DTLSSocket/tinydtls/dtls_debug.c",
+                 "DTLSSocket/tinydtls/ecc/ecc.c",
                  "DTLSSocket/tinydtls/dtls_time.c",
                  "DTLSSocket/tinydtls/hmac.c",
                  "DTLSSocket/tinydtls/netq.c",


### PR DESCRIPTION
Since Python 3.11, ecc.c did not get compiled automatically any more. The compile would succeed, but the final `.so` file would be missing the `ecc_g_point_y` and other symbols, resulting in errors like:

```python
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/chrysn/git/tinydtls-cython/build/lib.linux-x86_64-cpython-311/DTLSSocket/__init__.py", line 1, in <module>
    from .DTLSSocket import DTLSSocket as DTLSSocket
  File "/home/chrysn/git/tinydtls-cython/build/lib.linux-x86_64-cpython-311/DTLSSocket/DTLSSocket.py", line 2, in <module>
    from . import dtls
ImportError: /home/chrysn/git/tinydtls-cython/build/lib.linux-x86_64-cpython-311/DTLSSocket/dtls.cpython-311-x86_64-linux-gnu.so: undefined symbol: ecc_g_point_y
```

There was already an explicit list in setup.py ext_modules -- so whatever consumed that apparently did some automatic inclusion before which it doesn't do any more. (Didn't investigate any further).

With this PR, the module can be built and imported in Python 3.11.

When merging this, please consider publishing an updated version soon after -- then, downstream crates can enable DTLS testing for Python 3.11 again.