### PR TITLE
Pin Cython dependency to <3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["Cython", "setuptools", "wheel"]
+requires = ["Cython<3", "setuptools", "wheel"]

--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,8 @@ setup(
     url         = "https://git.fslab.de/jkonra2m/tinydtls-cython",
     py_modules  = [ "DTLSSocket.DTLSSocket"],
     cmdclass    = {"build_ext": prepare_tinydtls},
-    setup_requires = ['setuptools>=18.0','Cython'],
-    install_requires = ['Cython'],
+    setup_requires = ['setuptools>=18.0','Cython<3'],
+    install_requires = ['Cython<3'],
     ext_modules = [Extension("DTLSSocket.dtls",
                 [
                  "DTLSSocket/dtls.pyx",


### PR DESCRIPTION
DTLSSocket currently does not build with Cython 3.0.0 ([released yesterday](https://pypi.org/project/Cython/3.0.0/)).