### PR TITLE
Add SPDX license identifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ with open("README.md", "r") as fh:
 setup(
     name="DTLSSocket",
     version='0.2.2',
+    license='EPL-1.0',
     description = "DTLSSocket is a cython wrapper for tinydtls with a Socket like interface",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Add the SPDX license identifier as recommended by [PEP 639](https://peps.python.org/pep-0639/).
https://spdx.org/licenses/EPL-1.0.html